### PR TITLE
Declare MIT OR Apache-2.0 dual-license grant

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "cc-toolgate"
 version = "0.6.0"
 edition = "2024"
 description = "PreToolUse hook for Claude Code that gates Bash commands with compound-command-aware validation"
-license = "MIT"
+license = "MIT OR Apache-2.0"
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -285,4 +285,9 @@ Decisions are logged to `~/.local/share/cc-toolgate/decisions.log` (one line per
 
 ## License
 
-MIT
+Licensed under either of
+
+- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
+- MIT License ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+
+at your option.


### PR DESCRIPTION
## Summary

- Updated `Cargo.toml` license field from `MIT` to `MIT OR Apache-2.0`
- Updated README License section with the standard dual-license grant declaration linking to both LICENSE-APACHE and LICENSE-MIT

## Test plan

- [x] Verify `Cargo.toml` license field is `MIT OR Apache-2.0`
- [x] Verify README License section has the dual-license text with correct links

🤖 Generated with [Claude Code](https://claude.com/claude-code)