### PR TITLE
Fix pipeline redirect propagation in redirected_statement

### DIFF
--- a/src/parse/shell.rs
+++ b/src/parse/shell.rs
@@ -325,12 +325,13 @@ impl WalkResult {
 ///
 /// Apply a wrapping redirection to segments from a compound body.
 ///
-/// For `list` nodes (`&&`/`||`/`;` chains) only the last segment receives the
-/// redirect — earlier segments are independent commands whose output is not
-/// redirected.  For control-flow bodies (`for`/`while`/`if`/`case`) every
-/// segment is wrapped by the construct, so all receive the redirect.
+/// For `list` nodes (`&&`/`||`/`;` chains) and `pipeline` nodes (`|`/`|&`
+/// chains) only the last segment receives the redirect — earlier segments are
+/// independent commands whose output goes to the next pipe stage and is not
+/// itself redirected.  For control-flow bodies (`for`/`while`/`if`/`case`)
+/// every segment is wrapped by the construct, so all receive the redirect.
 fn propagate_redirect(result: &mut WalkResult, node_kind: &str, redir: &Redirection) {
-    if node_kind == "list" {
+    if node_kind == "list" || node_kind == "pipeline" {
         if let Some(last) = result.segments.last_mut()
             && last.redirection.is_none()
         {
@@ -1344,6 +1345,63 @@ mod tests {
             p.segments[2].redirection.is_some(),
             "last segment must carry redirection: {:?}",
             p.segments[2],
+        );
+    }
+
+    #[test]
+    fn redirect_pipeline_only_last_segment_gets_redir() {
+        // `echo hello | cat > /tmp/file` — only the last pipeline stage (cat)
+        // should carry the redirection; earlier stages' stdout goes to the pipe.
+        let (p, _) = parse_with_substitutions("echo hello | cat > /tmp/file");
+        assert_eq!(p.segments.len(), 2, "expected 2 segments: {:?}", p.segments);
+        assert!(
+            p.segments[0].redirection.is_none(),
+            "first pipeline stage must NOT carry redirection: {:?}",
+            p.segments[0],
+        );
+        assert!(
+            p.segments[1].redirection.is_some(),
+            "last pipeline stage must carry redirection: {:?}",
+            p.segments[1],
+        );
+    }
+
+    #[test]
+    fn redirect_pipeline_three_stages_only_last_gets_redir() {
+        // `a | b | c > file` — 3 pipeline stages, only last gets redirect.
+        let (p, _) = parse_with_substitutions("a | b | c > file");
+        assert_eq!(p.segments.len(), 3, "expected 3 segments: {:?}", p.segments);
+        assert!(
+            p.segments[0].redirection.is_none(),
+            "segment 0 must NOT carry redirection: {:?}",
+            p.segments[0],
+        );
+        assert!(
+            p.segments[1].redirection.is_none(),
+            "segment 1 must NOT carry redirection: {:?}",
+            p.segments[1],
+        );
+        assert!(
+            p.segments[2].redirection.is_some(),
+            "last segment must carry redirection: {:?}",
+            p.segments[2],
+        );
+    }
+
+    #[test]
+    fn redirect_pipeline_stderr_only_last_gets_redir() {
+        // `a |& b > file` — |& produces the same `pipeline` node kind as |.
+        let (p, _) = parse_with_substitutions("a |& b > file");
+        assert_eq!(p.segments.len(), 2, "expected 2 segments: {:?}", p.segments);
+        assert!(
+            p.segments[0].redirection.is_none(),
+            "first stage must NOT carry redirection: {:?}",
+            p.segments[0],
+        );
+        assert!(
+            p.segments[1].redirection.is_some(),
+            "last stage must carry redirection: {:?}",
+            p.segments[1],
         );
     }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -667,3 +667,27 @@ fn export_and_assign_before_redirect_segments_not_escalated() {
         "cat escalation reason must mention redirection, got: {reason}"
     );
 }
+
+// ── Pipeline redirection propagation (issue #37) ──
+
+decision_test!(
+    pipeline_with_trailing_redirect_asks,
+    "echo hello | cat > /tmp/file",
+    Ask
+);
+
+#[test]
+fn pipeline_redirect_only_last_stage_escalated() {
+    // Overall decision covered by pipeline_with_trailing_redirect_asks above;
+    // this test verifies per-segment eval results via the reason string.
+    let result = cc_toolgate::evaluate("echo hello | cat > /tmp/file");
+    let reason = &result.reason;
+    assert!(
+        reason.contains("echo hello") && reason.contains("ALLOW"),
+        "echo stage must be ALLOW, got: {reason}"
+    );
+    assert!(
+        reason.contains("cat") && reason.contains("ASK"),
+        "cat stage must be ASK (redirected), got: {reason}"
+    );
+}


### PR DESCRIPTION
Closes #37

## Summary

- Add `"pipeline"` alongside `"list"` in `propagate_redirect` so only the last pipeline stage receives the wrapping redirect
- In `echo hello | cat > /tmp/file`, only `cat`'s stdout is redirected to file; `echo hello`'s goes to the pipe — no longer incorrectly escalated to Ask
- Confirmed `|&` (stderr pipe) uses the same `pipeline` node kind — handled automatically

## Code Review Findings

Three parallel review agents (correctness, design, architecture/security). No P1 or P2 findings.

| # | Source | Sev | Title | Verdict |
|---|--------|-----|-------|---------|
| 1 | Design | P3→P3 | Integration test couples to reason-string format | Accepted — same pattern from #38, uses broad two-condition checks. Structured `SegmentResult` type would be better long-term. |
| 2 | Design | P3 | No test for `\|&` pipeline | **Fixed** — added `redirect_pipeline_stderr_only_last_gets_redir` |
| 3 | Design | P3 | Redundant decision assertion in manual test | **Fixed** — removed duplicate, added comment noting coverage by `decision_test!` |
| 4 | Correctness | — | No findings | Clean |
| 5 | Arch/Sec | — | No findings, confirmed `\|&` safe | Clean — verified `\|&` produces same `pipeline` node kind |

## Test plan

- [x] `cargo fmt -- --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo nextest run --workspace` — 432 passed, 0 failed
- [x] `cargo build --release` succeeds
- [x] `cargo doc --no-deps` succeeds
- [x] Verified via `--dump-ast` that `echo hello | cat > /tmp/file` correctly tags only `cat` with redirect

🤖 Generated with [Claude Code](https://claude.com/claude-code)