### PR TITLE
ci: Add release binary builds for Linux, macOS, and Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,32 @@ jobs:
       - run: cargo clippy -- -D warnings
       - run: cargo nextest run --no-fail-fast
 
+  # Catch cross-platform compilation failures before they reach the release pipeline.
+  # Mirrors the release.yml publish-binaries matrix.
+  cross-compile:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: universal-apple-darwin
+            os: macos-latest
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9 # master (2026-02-13)
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          key: ${{ matrix.target }}
+      - run: cargo build --release
+
   msrv:
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,44 @@ jobs:
           gh run watch "$run_id" --repo "${{ github.repository }}" --exit-status > /dev/null
           echo "CI run $run_id passed."
 
+  # Build release binaries and upload them as GitHub release assets.
+  publish-binaries:
+    needs: [release-please, ci-gate]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+            build-tool: cargo
+          - target: universal-apple-darwin
+            os: macos-latest
+            build-tool: cargo
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+            build-tool: cargo
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ needs.release-please.outputs.tag_name }}
+      - uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9 # master (2026-02-13)
+        with:
+          toolchain: stable
+      - uses: taiki-e/upload-rust-binary-action@0e34102c043ded9f2ca39f7af5cd99a540c61aff # v1.29.1
+        with:
+          bin: cc-toolgate
+          target: ${{ matrix.target }}
+          build-tool: ${{ matrix.build-tool }}
+          archive: cc-toolgate-$tag-$target
+          tar: all
+          zip: windows
+          checksum: sha256
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ref: refs/tags/${{ needs.release-please.outputs.tag_name }}
+
   publish-crate:
     needs: [release-please, ci-gate]
     runs-on: ubuntu-latest
@@ -84,8 +122,9 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
 
+  # Undraft the release after all artifacts (binaries + crate) are uploaded.
   publish-release:
-    needs: [release-please, publish-crate]
+    needs: [release-please, publish-binaries, publish-crate]
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Summary

Adds a `publish-binaries` matrix job to `release.yml` that builds prebuilt binaries on release:

| Target | Runner | Archive format |
|--------|--------|---------------|
| `x86_64-unknown-linux-gnu` | ubuntu-latest | `.tar.gz` |
| `universal-apple-darwin` | macos-latest | `.tar.gz` |
| `x86_64-pc-windows-msvc` | windows-latest | `.zip` |

Each archive includes sha256 checksums. `publish-release` now waits for both `publish-binaries` and `publish-crate` before undrafting.

Uses `taiki-e/upload-rust-binary-action@v1.29.1` (same as memory-mcp). Windows is new — cc-toolgate has no platform-specific deps so it should build cleanly, but we'll find out on the first build here in this PR.

## Test plan

- [x] Workflow YAML is valid
- [x] Windows build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)