### PR TITLE
feat: shared SubcommandMatcher, path canonicalization, git-town support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9 # master (2026-02-13)
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master (2026-03-27)
         with:
           toolchain: stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
@@ -52,7 +52,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9 # master (2026-02-13)
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master (2026-03-27)
         with:
           toolchain: stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
@@ -66,7 +66,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9 # master (2026-02-13)
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master (2026-03-27)
         with:
           toolchain: "1.88"
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
@@ -80,6 +80,21 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: EmbarkStudios/cargo-deny-action@82eb9f621fbc699dd0918f3ea06864c14cc84246 # v2.0.15
+      - uses: EmbarkStudios/cargo-deny-action@91bf2b620e09e18d6eb78b92e7861937469acedb # v2.0.17
         with:
           command: check
+
+  semver-checks:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master (2026-03-27)
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          key: semver
+      - uses: obi1kenobi/cargo-semver-checks-action@6b69fcf40e9b5fb17adeb57e4b6ecd020649a239 # v2.9

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,7 +23,7 @@ dependencies = [
 
 [[package]]
 name = "cc-toolgate"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cc-toolgate"
-version = "0.6.2"
+version = "0.7.0"
 edition = "2024"
 description = "PreToolUse hook for Claude Code that gates Bash commands with compound-command-aware validation"
 license = "MIT OR Apache-2.0"

--- a/config.default.toml
+++ b/config.default.toml
@@ -48,11 +48,9 @@ allow = [
     # Environment
     "printenv", "locale",
     # Shell builtins / control
-    # Note: source/. can execute arbitrary code. They're allowed by default
-    # because Claude Code commonly uses them for env setup. Move to ask list
-    # with remove_allow = ["source", "."] if this concerns you.
+    # source/. execute arbitrary code — kept in ask, not allow
     "test", "[", "true", "false", "type", "command", "hash",
-    "export", "unset", "set", "source", ".",
+    "export", "unset", "set",
     "sleep", "seq", "yes",
     # Process inspection
     "ps", "top", "htop", "pgrep",
@@ -75,6 +73,8 @@ ask = [
     "pip", "pip3", "npm", "npx", "yarn", "pnpm",
     "python", "python3", "node", "ruby", "perl",
     "make", "cmake", "ninja",
+    # source/. execute arbitrary code
+    "source", ".",
 ]
 
 deny = [
@@ -109,6 +109,29 @@ read_only = [
     "status", "log", "diff", "show", "branch", "tag", "remote",
     "rev-parse", "ls-files", "ls-tree", "shortlog",
     "blame", "describe", "stash",
+    # fetch is read-only (downloads objects but does not modify working tree or branches)
+    "fetch",
+    # --version: treated as a subcommand by the extractor (git --version has no subcommand word)
+    "--version",
+    # git-town: informational / read-only
+    "town branch", "town config", "town diff-parent", "town help",
+    "town status", "town runlog", "town completions", "town offline",
+]
+
+# Safe local operations — auto-allowed.
+allow = [
+    # git-town: local branch management
+    "town hack", "town append", "town prepend", "town set-parent",
+    "town swap", "town detach", "town down", "town up", "town switch",
+    "town contribute", "town feature", "town observe", "town park",
+    "town prototype", "town init", "town continue", "town skip",
+    "town undo", "town rename", "town compress", "town walk",
+    "town commit", "town merge",
+]
+
+# Mutating operations — always ask.
+mutating = [
+    "town sync", "town ship", "town propose", "town delete", "town repo",
 ]
 
 # Subcommands auto-allowed only when all config_env entries match.

--- a/config.default.toml
+++ b/config.default.toml
@@ -113,6 +113,8 @@ read_only = [
     "fetch",
     # --version: treated as a subcommand by the extractor (git --version has no subcommand word)
     "--version",
+    # git-town: bare `git town` shows help
+    "town",
     # git-town: informational / read-only
     "town branch", "town config", "town diff-parent", "town help",
     "town status", "town runlog", "town completions", "town offline",
@@ -131,7 +133,12 @@ allow = [
 
 # Mutating operations — always ask.
 mutating = [
+    # git-town: remote-affecting
     "town sync", "town ship", "town propose", "town delete", "town repo",
+    # destructive stash/remote operations (one-word prefixes are in read_only,
+    # but the two-word match takes precedence when matched)
+    "stash drop", "stash clear",
+    "remote add", "remote remove", "remote rename", "remote set-url",
 ]
 
 # Subcommands auto-allowed only when all config_env entries match.

--- a/src/commands/simple.rs
+++ b/src/commands/simple.rs
@@ -24,32 +24,35 @@ impl CommandSpec for SimpleCommandSpec {
     fn evaluate(&self, ctx: &CommandContext) -> RuleMatch {
         match self.decision {
             Decision::Allow => {
-                // Check for --version on any allowed command
                 if ctx.words.len() <= 3 && ctx.has_flag("--version") {
                     return RuleMatch {
                         decision: Decision::Allow,
                         reason: format!("{} --version", ctx.base_command),
+                        matched: true,
                     };
                 }
-                // Redirection escalates ALLOW → ASK
                 if let Some(ref r) = ctx.redirection {
                     return RuleMatch {
                         decision: Decision::Ask,
                         reason: format!("{} with {}", ctx.base_command, r.description),
+                        matched: true,
                     };
                 }
                 RuleMatch {
                     decision: Decision::Allow,
                     reason: format!("allowed: {}", ctx.base_command),
+                    matched: true,
                 }
             }
             Decision::Ask => RuleMatch {
                 decision: Decision::Ask,
                 reason: format!("{} requires confirmation", ctx.base_command),
+                matched: true,
             },
             Decision::Deny => RuleMatch {
                 decision: Decision::Deny,
                 reason: format!("blocked command: {}", ctx.base_command),
+                matched: true,
             },
         }
     }

--- a/src/commands/tools/cargo.rs
+++ b/src/commands/tools/cargo.rs
@@ -74,6 +74,7 @@ impl CommandSpec for CargoSpec {
             return RuleMatch {
                 decision: Decision::Allow,
                 reason: "cargo --version".into(),
+                matched: true,
             };
         }
 

--- a/src/commands/tools/cargo.rs
+++ b/src/commands/tools/cargo.rs
@@ -5,32 +5,49 @@
 
 use super::super::CommandSpec;
 use crate::config::CargoConfig;
+use crate::eval::matcher::SubcommandMatcher;
 use crate::eval::{CommandContext, Decision, RuleMatch};
-use std::collections::HashMap;
 
 /// Subcommand-aware cargo evaluator.
 ///
 /// Evaluation order:
-/// 1. Safe subcommands → ALLOW (with redirection escalation)
-/// 2. Env-gated subcommands → ALLOW if all `config_env` entries match, else ASK
-/// 3. `--version` / `-V` → ALLOW
-/// 4. Everything else → ASK
+/// 1. `--version` / `-V` at any position → ALLOW
+///    (checked before subcommand extraction: `cargo -V` has no subcommand word)
+/// 2. Safe subcommands (`safe_subcommands`) → ALLOW (redirection escalates to ASK)
+/// 3. Read-only subcommands → ALLOW (redirection escalates to ASK)
+/// 4. Env-gated subcommands → ALLOW if all `config_env` entries match, else ASK
+/// 5. Mutating subcommands → ASK
+/// 6. Everything else → ASK
+///
+/// Note: `--version`/`-V` is checked first because `cargo --version` produces no
+/// subcommand word and would otherwise fall through to "requires confirmation".
+/// The `has_any_flag` check is kept here (not in config) because it's a flag
+/// pattern, not a subcommand, and doesn't fit the SubcommandMatcher model.
 pub struct CargoSpec {
-    /// Subcommands that are always safe (e.g. `build`, `test`, `check`).
-    safe_subcommands: Vec<String>,
-    /// Subcommands allowed only when all `config_env` entries match.
-    allowed_with_config: Vec<String>,
-    /// Required env var name→value pairs that gate `allowed_with_config` subcommands.
-    config_env: HashMap<String, String>,
+    matcher: SubcommandMatcher,
 }
 
 impl CargoSpec {
     /// Build a cargo spec from configuration.
+    ///
+    /// `safe_subcommands` and `read_only` are both unconditionally-allowed lists;
+    /// they are combined into the matcher's `read_only` slot.
     pub fn from_config(config: &CargoConfig) -> Self {
+        // Merge safe_subcommands + read_only into a single read_only list.
+        let mut read_only = config.safe_subcommands.clone();
+        for s in &config.read_only {
+            if !read_only.contains(s) {
+                read_only.push(s.clone());
+            }
+        }
         Self {
-            safe_subcommands: config.safe_subcommands.clone(),
-            allowed_with_config: config.allowed_with_config.clone(),
-            config_env: config.config_env.clone(),
+            matcher: SubcommandMatcher::new(
+                read_only,
+                vec![], // cargo has no unconditional "allow" tier between read_only and gated
+                config.mutating.clone(),
+                config.allowed_with_config.clone(),
+                config.config_env.clone(),
+            ),
         }
     }
 
@@ -45,53 +62,14 @@ impl CargoSpec {
         }
         None
     }
-
-    /// Format config_env keys for reason strings.
-    fn env_keys_display(&self) -> String {
-        let mut keys: Vec<&str> = self.config_env.keys().map(|k| k.as_str()).collect();
-        keys.sort();
-        keys.join(", ")
-    }
 }
 
 impl CommandSpec for CargoSpec {
     fn evaluate(&self, ctx: &CommandContext) -> RuleMatch {
-        let sub_str = Self::subcommand(ctx).unwrap_or("?");
-
-        if self.safe_subcommands.iter().any(|s| s == sub_str) {
-            if let Some(ref r) = ctx.redirection {
-                return RuleMatch {
-                    decision: Decision::Ask,
-                    reason: format!("cargo {sub_str} with {}", r.description),
-                };
-            }
-            return RuleMatch {
-                decision: Decision::Allow,
-                reason: format!("cargo {sub_str}"),
-            };
-        }
-
-        // Env-gated subcommands: allowed only when all config_env entries match
-        if self.allowed_with_config.iter().any(|s| s == sub_str) {
-            if !self.config_env.is_empty() && ctx.env_satisfies(&self.config_env) {
-                if let Some(ref r) = ctx.redirection {
-                    return RuleMatch {
-                        decision: Decision::Ask,
-                        reason: format!("cargo {sub_str} with {}", r.description),
-                    };
-                }
-                return RuleMatch {
-                    decision: Decision::Allow,
-                    reason: format!("cargo {sub_str} with {}", self.env_keys_display()),
-                };
-            }
-            return RuleMatch {
-                decision: Decision::Ask,
-                reason: format!("cargo {sub_str} requires confirmation"),
-            };
-        }
-
-        // --version / -V at any position
+        // Check --version/-V before extracting a subcommand: `cargo --version` and
+        // `cargo -V` have no subcommand word and would otherwise fall through.
+        // TODO(review): consider adding "--version" and "-V" as read_only subcommands
+        // in config instead, but that requires the matcher to understand flag-as-subcommand.
         if ctx.has_any_flag(&["--version", "-V"]) {
             return RuleMatch {
                 decision: Decision::Allow,
@@ -99,17 +77,17 @@ impl CommandSpec for CargoSpec {
             };
         }
 
-        RuleMatch {
-            decision: Decision::Ask,
-            reason: format!("cargo {sub_str} requires confirmation"),
-        }
+        let sub = Self::subcommand(ctx).unwrap_or("?");
+        self.matcher.evaluate(ctx, "cargo", sub)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::Config;
+    use crate::config::{CargoConfig, Config};
+    use crate::eval::CommandContext;
+    use std::collections::HashMap;
 
     fn spec() -> CargoSpec {
         CargoSpec::from_config(&Config::default_config().cargo)
@@ -166,6 +144,8 @@ mod tests {
     fn spec_with_env_gate() -> CargoSpec {
         CargoSpec::from_config(&CargoConfig {
             safe_subcommands: vec!["build".into(), "check".into(), "test".into()],
+            read_only: vec![],
+            mutating: vec![],
             allowed_with_config: vec!["install".into(), "publish".into()],
             config_env: HashMap::from([("CARGO_INSTALL_ROOT".into(), "/tmp/bin".into())]),
         })

--- a/src/commands/tools/gh.rs
+++ b/src/commands/tools/gh.rs
@@ -40,22 +40,36 @@ impl GhSpec {
         }
     }
 
-    /// Get the two-word subcommand (e.g. "pr list") and one-word fallback ("pr").
-    /// Handles env var prefixes like `GH_TOKEN=abc gh pr create`.
-    fn subcommands(ctx: &CommandContext) -> (String, String) {
-        let gh_pos = ctx.words.iter().position(|w| w == "gh");
-        let after_gh = gh_pos.map(|p| p + 1).unwrap_or(1);
+    /// Global gh flags that consume the next word as their argument.
+    const GLOBAL_ARG_FLAGS: &[&str] = &["--hostname", "-R", "--repo"];
 
-        let sub_two = if ctx.words.len() > after_gh + 1 {
-            format!("{} {}", ctx.words[after_gh], ctx.words[after_gh + 1])
-        } else {
-            String::new()
+    /// Extract subcommands, skipping global flags.
+    /// Returns `(two_word, one_word)` like `("pr list", "pr")`.
+    fn subcommands(ctx: &CommandContext) -> (String, String) {
+        let mut iter = ctx.words.iter();
+        for word in iter.by_ref() {
+            if word == "gh" {
+                break;
+            }
+        }
+        let sub_one = loop {
+            let word = match iter.next() {
+                Some(w) => w,
+                None => return (String::new(), "?".into()),
+            };
+            if Self::GLOBAL_ARG_FLAGS.contains(&word.as_str()) {
+                iter.next();
+                continue;
+            }
+            if word.starts_with('-') {
+                continue;
+            }
+            break word.clone();
         };
-        let sub_one = ctx
-            .words
-            .get(after_gh)
-            .cloned()
-            .unwrap_or_else(|| "?".to_string());
+        let sub_two = iter
+            .find(|w| !w.starts_with('-'))
+            .map(|w| format!("{sub_one} {w}"))
+            .unwrap_or_default();
         (sub_two, sub_one)
     }
 }
@@ -69,38 +83,27 @@ impl CommandSpec for GhSpec {
             return RuleMatch {
                 decision: Decision::Allow,
                 reason: "gh --version".into(),
+                matched: true,
             };
         }
 
         let (sub_two, sub_one) = Self::subcommands(ctx);
 
-        // Try the two-word subcommand first. If it's recognized (ALLOW or a
-        // config-driven ASK), use that result. If it falls through as an
-        // unrecognized subcommand, try the one-word fallback — this handles
-        // one-word commands like `gh status` that aren't two-word forms.
-        //
-        // TODO(review): this "try two then one" probe has a subtle edge: if
-        // sub_two is empty (e.g. bare `gh`), sub_one becomes "?" and both
-        // return "requires confirmation". That's correct behavior — bare `gh`
-        // should ask. But if gh gains a recognized one-word command that also
-        // appears as the first word of a two-word form (e.g. `gh status` and
-        // `gh status refresh`), the two-word probe fires first, which is right.
+        // Try two-word first, fall back to one-word only if unrecognized.
         if !sub_two.is_empty() {
             let two_result = self.matcher.evaluate(ctx, "gh", &sub_two);
             if two_result.decision == Decision::Allow {
                 return two_result;
             }
-            // Two-word fell through (unrecognized) — try one-word fallback.
-            // If the one-word form is recognized as ALLOW, use it.
-            // Otherwise keep the two-word reason (more informative).
-            let one_result = self.matcher.evaluate(ctx, "gh", &sub_one);
-            if one_result.decision == Decision::Allow {
-                return one_result;
+            if !two_result.matched {
+                let one_result = self.matcher.evaluate(ctx, "gh", &sub_one);
+                if one_result.decision == Decision::Allow {
+                    return one_result;
+                }
             }
             return two_result;
         }
 
-        // No two-word form available — evaluate the one-word subcommand directly.
         self.matcher.evaluate(ctx, "gh", &sub_one)
     }
 }

--- a/src/commands/tools/gh.rs
+++ b/src/commands/tools/gh.rs
@@ -1,47 +1,48 @@
 //! Subcommand-aware GitHub CLI (gh) evaluation.
 //!
-//! gh uses two-word subcommands (`pr list`, `issue create`), so both the
-//! two-word form and one-word fallback are checked against the config lists.
-//! Supports env-gated auto-allow and redirection escalation.
+//! gh uses two-word subcommands (`pr list`, `issue create`), so the spec
+//! extracts both the two-word form and the one-word fallback, then tries
+//! them in order against the matcher. The `allow` field supports future
+//! gh subcommands that are safe but neither read-only nor env-gated.
 
 use super::super::CommandSpec;
 use crate::config::GhConfig;
+use crate::eval::matcher::SubcommandMatcher;
 use crate::eval::{CommandContext, Decision, RuleMatch};
-use std::collections::HashMap;
 
 /// Subcommand-aware gh CLI evaluator.
 ///
 /// Evaluation order:
-/// 1. Read-only subcommands → ALLOW (with redirection escalation)
-/// 2. Env-gated subcommands → ALLOW if all `config_env` entries match, else ASK
-/// 3. Known mutating subcommands → ASK
-/// 4. Everything else → ASK
+/// 1. Try two-word subcommand (`pr list`) through the matcher pipeline
+/// 2. If matcher returns ASK on the two-word form, try one-word fallback (`pr`)
+///    — only upgrades to ALLOW; ASK/Deny stays at two-word result
+/// 3. Pipeline: read_only → allow → allowed_with_config → mutating → fallthrough
+///
+/// Note: the two-word-then-one-word probe order ensures that `pr list` in
+/// `read_only` matches before `pr` alone could hit `mutating`. The one-word
+/// fallback only fires when the two-word form isn't recognized, so it can
+/// never override an explicit two-word classification.
 pub struct GhSpec {
-    /// Read-only subcommands (e.g. `pr list`, `pr view`, `status`).
-    read_only: Vec<String>,
-    /// Known mutating subcommands (e.g. `pr create`, `repo delete`).
-    mutating: Vec<String>,
-    /// Subcommands allowed only when all `config_env` entries match.
-    allowed_with_config: Vec<String>,
-    /// Required env var name→value pairs that gate `allowed_with_config` subcommands.
-    config_env: HashMap<String, String>,
+    matcher: SubcommandMatcher,
 }
 
 impl GhSpec {
     /// Build a gh spec from configuration.
     pub fn from_config(config: &GhConfig) -> Self {
         Self {
-            read_only: config.read_only.clone(),
-            mutating: config.mutating.clone(),
-            allowed_with_config: config.allowed_with_config.clone(),
-            config_env: config.config_env.clone(),
+            matcher: SubcommandMatcher::new(
+                config.read_only.clone(),
+                config.allow.clone(),
+                config.mutating.clone(),
+                config.allowed_with_config.clone(),
+                config.config_env.clone(),
+            ),
         }
     }
 
-    /// Get the two-word subcommand (e.g. "pr list") and one-word fallback.
+    /// Get the two-word subcommand (e.g. "pr list") and one-word fallback ("pr").
     /// Handles env var prefixes like `GH_TOKEN=abc gh pr create`.
     fn subcommands(ctx: &CommandContext) -> (String, String) {
-        // Find position of "gh" in the word list (may be preceded by env vars)
         let gh_pos = ctx.words.iter().position(|w| w == "gh");
         let after_gh = gh_pos.map(|p| p + 1).unwrap_or(1);
 
@@ -57,76 +58,59 @@ impl GhSpec {
             .unwrap_or_else(|| "?".to_string());
         (sub_two, sub_one)
     }
-
-    /// Format config_env keys for reason strings.
-    fn env_keys_display(&self) -> String {
-        let mut keys: Vec<&str> = self.config_env.keys().map(|k| k.as_str()).collect();
-        keys.sort();
-        keys.join(", ")
-    }
 }
 
 impl CommandSpec for GhSpec {
     fn evaluate(&self, ctx: &CommandContext) -> RuleMatch {
-        let (sub_two, sub_one) = Self::subcommands(ctx);
-
-        let in_read_only = self.read_only.iter().any(|s| s == &sub_two)
-            || self.read_only.iter().any(|s| s == &sub_one);
-        if in_read_only {
-            if let Some(ref r) = ctx.redirection {
-                return RuleMatch {
-                    decision: Decision::Ask,
-                    reason: format!("gh {sub_one} with {}", r.description),
-                };
-            }
+        // `gh --version` has no subcommand word; the extractor returns "--version"
+        // as sub_one, which never matches any config list. Handle it here — same
+        // pattern as cargo's --version/-V pre-check.
+        if ctx.has_flag("--version") {
             return RuleMatch {
                 decision: Decision::Allow,
-                reason: format!("read-only gh {sub_two}"),
+                reason: "gh --version".into(),
             };
         }
 
-        // Env-gated subcommands: allowed only when all config_env entries match
-        let in_env_gated = self.allowed_with_config.iter().any(|s| s == &sub_two)
-            || self.allowed_with_config.iter().any(|s| s == &sub_one);
-        if in_env_gated {
-            if !self.config_env.is_empty() && ctx.env_satisfies(&self.config_env) {
-                if let Some(ref r) = ctx.redirection {
-                    return RuleMatch {
-                        decision: Decision::Ask,
-                        reason: format!("gh {sub_one} with {}", r.description),
-                    };
-                }
-                return RuleMatch {
-                    decision: Decision::Allow,
-                    reason: format!("gh {sub_two} with {}", self.env_keys_display()),
-                };
+        let (sub_two, sub_one) = Self::subcommands(ctx);
+
+        // Try the two-word subcommand first. If it's recognized (ALLOW or a
+        // config-driven ASK), use that result. If it falls through as an
+        // unrecognized subcommand, try the one-word fallback — this handles
+        // one-word commands like `gh status` that aren't two-word forms.
+        //
+        // TODO(review): this "try two then one" probe has a subtle edge: if
+        // sub_two is empty (e.g. bare `gh`), sub_one becomes "?" and both
+        // return "requires confirmation". That's correct behavior — bare `gh`
+        // should ask. But if gh gains a recognized one-word command that also
+        // appears as the first word of a two-word form (e.g. `gh status` and
+        // `gh status refresh`), the two-word probe fires first, which is right.
+        if !sub_two.is_empty() {
+            let two_result = self.matcher.evaluate(ctx, "gh", &sub_two);
+            if two_result.decision == Decision::Allow {
+                return two_result;
             }
-            return RuleMatch {
-                decision: Decision::Ask,
-                reason: format!("gh {sub_two} requires confirmation"),
-            };
+            // Two-word fell through (unrecognized) — try one-word fallback.
+            // If the one-word form is recognized as ALLOW, use it.
+            // Otherwise keep the two-word reason (more informative).
+            let one_result = self.matcher.evaluate(ctx, "gh", &sub_one);
+            if one_result.decision == Decision::Allow {
+                return one_result;
+            }
+            return two_result;
         }
 
-        let in_mutating = self.mutating.iter().any(|s| s == &sub_two)
-            || self.mutating.iter().any(|s| s == &sub_one);
-        if in_mutating {
-            return RuleMatch {
-                decision: Decision::Ask,
-                reason: format!("gh {sub_two} requires confirmation"),
-            };
-        }
-
-        RuleMatch {
-            decision: Decision::Ask,
-            reason: format!("gh {sub_one} requires confirmation"),
-        }
+        // No two-word form available — evaluate the one-word subcommand directly.
+        self.matcher.evaluate(ctx, "gh", &sub_one)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::Config;
+    use crate::config::{Config, GhConfig};
+    use crate::eval::CommandContext;
+    use std::collections::HashMap;
 
     fn spec() -> GhSpec {
         GhSpec::from_config(&Config::default_config().gh)
@@ -174,6 +158,11 @@ mod tests {
     }
 
     #[test]
+    fn allow_version() {
+        assert_eq!(eval("gh --version"), Decision::Allow);
+    }
+
+    #[test]
     fn redir_pr_list() {
         assert_eq!(eval("gh pr list > /tmp/prs.txt"), Decision::Ask);
     }
@@ -183,6 +172,7 @@ mod tests {
     fn spec_with_env_gate() -> GhSpec {
         GhSpec::from_config(&GhConfig {
             read_only: vec!["pr list".into(), "pr view".into(), "status".into()],
+            allow: vec![],
             mutating: vec!["repo delete".into()],
             allowed_with_config: vec!["pr create".into(), "pr merge".into()],
             config_env: HashMap::from([("GH_CONFIG_DIR".into(), "~/.config/gh-ai".into())]),

--- a/src/commands/tools/git.rs
+++ b/src/commands/tools/git.rs
@@ -6,24 +6,27 @@
 
 use super::super::CommandSpec;
 use crate::config::GitConfig;
+use crate::eval::matcher::SubcommandMatcher;
 use crate::eval::{CommandContext, Decision, RuleMatch};
-use std::collections::HashMap;
 
 /// Subcommand-aware git evaluator.
 ///
 /// Evaluation order:
-/// 1. Force-push flags → always ASK
-/// 2. Read-only subcommands → ALLOW (with redirection escalation)
-/// 3. Env-gated subcommands → ALLOW if all `config_env` entries match, else ASK
-/// 4. `--version` → ALLOW
-/// 5. Everything else → ASK
+/// 1. Force-push flags on `push` → always ASK
+/// 2. Read-only subcommands → ALLOW (redirection escalates to ASK)
+/// 3. Unconditionally-allowed subcommands → ALLOW (redirection escalates to ASK)
+/// 4. Env-gated subcommands → ALLOW if all `config_env` entries match, else ASK
+/// 5. Explicitly mutating subcommands → ASK
+/// 6. Everything else → ASK
+///
+/// `--version` lives in `read_only` (in config), so `git --version` is
+/// handled by step 2. Redirection on `git --version > file` escalates to
+/// ASK, which is correct behavior.
+// TODO(review): --version moved from post-pipeline special case to config.read_only.
+// The old check had `words.len() <= 3` guard; read_only has no such guard, but
+// `git --version --extra-arg` is harmless to allow. Revisit if that matters.
 pub struct GitSpec {
-    /// Git subcommands that are always allowed (e.g. `status`, `log`, `diff`).
-    read_only: Vec<String>,
-    /// Subcommands allowed only when all `config_env` entries match.
-    allowed_with_config: Vec<String>,
-    /// Required env var name→value pairs that gate `allowed_with_config` subcommands.
-    config_env: HashMap<String, String>,
+    matcher: SubcommandMatcher,
     /// Flags indicating force-push (always ASK regardless of env-gating).
     force_push_flags: Vec<String>,
 }
@@ -32,9 +35,13 @@ impl GitSpec {
     /// Build a git spec from configuration.
     pub fn from_config(config: &GitConfig) -> Self {
         Self {
-            read_only: config.read_only.clone(),
-            allowed_with_config: config.allowed_with_config.clone(),
-            config_env: config.config_env.clone(),
+            matcher: SubcommandMatcher::new(
+                config.read_only.clone(),
+                config.allow.clone(),
+                config.mutating.clone(),
+                config.allowed_with_config.clone(),
+                config.config_env.clone(),
+            ),
             force_push_flags: config.force_push_flags.clone(),
         }
     }
@@ -55,9 +62,18 @@ impl GitSpec {
         "--no-optional-locks",
     ];
 
-    /// Extract the git subcommand word (e.g. "push" from "git push origin main").
+    /// Extract the git subcommand, returning both a two-word form and one-word form.
+    ///
+    /// Returns `(two_word, one_word)` where `two_word` is `"<sub> <next>"` (e.g.
+    /// `"town hack"`) and `one_word` is just `"<sub>"` (e.g. `"town"`). When
+    /// there is no following word, `two_word` is empty.
+    ///
+    /// This enables matching multi-word plugin subcommands like `git town hack`
+    /// against config entries like `"town hack"`, using the same two-word probe
+    /// pattern as the gh evaluator.
+    ///
     /// Skips global flags like `-C <path>` that appear before the subcommand.
-    fn subcommand(ctx: &CommandContext) -> Option<String> {
+    fn subcommands(ctx: &CommandContext) -> (String, String) {
         let mut iter = ctx.words.iter();
         // Advance past env vars to find "git"
         for word in iter.by_ref() {
@@ -66,36 +82,35 @@ impl GitSpec {
             }
         }
         // Skip global flags to find the subcommand
-        loop {
-            let word = iter.next()?;
+        let sub_one = loop {
+            let word = match iter.next() {
+                Some(w) => w,
+                None => return (String::new(), "?".into()),
+            };
             if Self::GLOBAL_ARG_FLAGS.contains(&word.as_str()) {
-                // Consume the flag's argument
-                iter.next();
+                iter.next(); // consume flag argument
                 continue;
             }
             if Self::GLOBAL_SOLO_FLAGS.contains(&word.as_str()) {
                 continue;
             }
-            // Not a global flag — this is the subcommand
-            return Some(word.clone());
-        }
-    }
-
-    /// Format config_env keys for reason strings (e.g. "GIT_CONFIG_GLOBAL").
-    fn env_keys_display(&self) -> String {
-        let mut keys: Vec<&str> = self.config_env.keys().map(|k| k.as_str()).collect();
-        keys.sort();
-        keys.join(", ")
+            break word.clone();
+        };
+        // Build two-word form if a next word exists (and it's not a flag)
+        let sub_two = iter
+            .find(|w| !w.starts_with('-'))
+            .map(|w| format!("{sub_one} {w}"))
+            .unwrap_or_default();
+        (sub_two, sub_one)
     }
 }
 
 impl CommandSpec for GitSpec {
     fn evaluate(&self, ctx: &CommandContext) -> RuleMatch {
-        let sub = Self::subcommand(ctx);
-        let sub_str = sub.as_deref().unwrap_or("?");
+        let (sub_two, sub_one) = Self::subcommands(ctx);
 
-        // Force-push → ask regardless of config
-        if sub_str == "push" {
+        // Force-push flags on `push` → ask regardless of config.
+        if sub_one == "push" {
             let flag_strs: Vec<&str> = self.force_push_flags.iter().map(|s| s.as_str()).collect();
             if ctx.has_any_flag(&flag_strs) {
                 return RuleMatch {
@@ -105,52 +120,22 @@ impl CommandSpec for GitSpec {
             }
         }
 
-        // Read-only git subcommands — always allowed
-        if self.read_only.iter().any(|s| s == sub_str) {
-            if let Some(ref r) = ctx.redirection {
-                return RuleMatch {
-                    decision: Decision::Ask,
-                    reason: format!("git {sub_str} with {}", r.description),
-                };
+        // Try two-word subcommand first (e.g. "town hack"), fall back to one-word
+        // (e.g. "town") if the two-word form isn't recognized. Same probe pattern
+        // as the gh evaluator — see that module for the rationale.
+        if !sub_two.is_empty() {
+            let two_result = self.matcher.evaluate(ctx, "git", &sub_two);
+            if two_result.decision == Decision::Allow {
+                return two_result;
             }
-            return RuleMatch {
-                decision: Decision::Allow,
-                reason: format!("read-only git {sub_str}"),
-            };
-        }
-
-        // Env-gated subcommands: allowed only when all config_env entries match
-        if self.allowed_with_config.iter().any(|s| s == sub_str) {
-            if !self.config_env.is_empty() && ctx.env_satisfies(&self.config_env) {
-                if let Some(ref r) = ctx.redirection {
-                    return RuleMatch {
-                        decision: Decision::Ask,
-                        reason: format!("git {sub_str} with {}", r.description),
-                    };
-                }
-                return RuleMatch {
-                    decision: Decision::Allow,
-                    reason: format!("git {sub_str} with {}", self.env_keys_display()),
-                };
+            let one_result = self.matcher.evaluate(ctx, "git", &sub_one);
+            if one_result.decision == Decision::Allow {
+                return one_result;
             }
-            return RuleMatch {
-                decision: Decision::Ask,
-                reason: format!("git {sub_str} requires confirmation"),
-            };
+            return two_result;
         }
 
-        // --version check
-        if ctx.has_flag("--version") && ctx.words.len() <= 3 {
-            return RuleMatch {
-                decision: Decision::Allow,
-                reason: "git --version".into(),
-            };
-        }
-
-        RuleMatch {
-            decision: Decision::Ask,
-            reason: format!("git {sub_str} requires confirmation"),
-        }
+        self.matcher.evaluate(ctx, "git", &sub_one)
     }
 }
 
@@ -158,6 +143,8 @@ impl CommandSpec for GitSpec {
 mod tests {
     use super::*;
     use crate::config::{Config, GitConfig};
+    use crate::eval::CommandContext;
+    use std::collections::HashMap;
 
     /// Clear `GIT_CONFIG_GLOBAL` from the process environment so the
     /// env-gate fallback in `env_satisfies` doesn't interfere with tests
@@ -189,6 +176,8 @@ mod tests {
                 "diff".into(),
                 "branch".into(),
             ],
+            allow: vec![],
+            mutating: vec![],
             allowed_with_config: vec!["push".into(), "pull".into(), "add".into()],
             config_env: HashMap::from([("GIT_CONFIG_GLOBAL".into(), "~/.gitconfig.ai".into())]),
             force_push_flags: vec!["--force".into(), "-f".into(), "--force-with-lease".into()],
@@ -235,6 +224,11 @@ mod tests {
     #[test]
     fn allow_status() {
         assert_eq!(eval("git status"), Decision::Allow);
+    }
+
+    #[test]
+    fn allow_version() {
+        assert_eq!(eval("git --version"), Decision::Allow);
     }
 
     #[test]
@@ -314,5 +308,37 @@ mod tests {
     fn allow_git_c_config_status() {
         // -c key=value is also a global flag
         assert_eq!(eval("git -c core.pager=cat status"), Decision::Allow);
+    }
+
+    // ── allow list (git-town local commands) ──
+
+    #[test]
+    fn allow_list_allows_town_hack() {
+        let spec = GitSpec::from_config(&GitConfig {
+            read_only: vec![],
+            allow: vec!["town hack".into()],
+            mutating: vec![],
+            allowed_with_config: vec![],
+            config_env: HashMap::new(),
+            force_push_flags: vec![],
+        });
+        let ctx = CommandContext::from_command("git town hack feature-branch");
+        assert_eq!(spec.evaluate(&ctx).decision, Decision::Allow);
+    }
+
+    // ── mutating list ──
+
+    #[test]
+    fn mutating_list_asks_town_sync() {
+        let spec = GitSpec::from_config(&GitConfig {
+            read_only: vec![],
+            allow: vec![],
+            mutating: vec!["town sync".into()],
+            allowed_with_config: vec![],
+            config_env: HashMap::new(),
+            force_push_flags: vec![],
+        });
+        let ctx = CommandContext::from_command("git town sync");
+        assert_eq!(spec.evaluate(&ctx).decision, Decision::Ask);
     }
 }

--- a/src/commands/tools/git.rs
+++ b/src/commands/tools/git.rs
@@ -116,21 +116,25 @@ impl CommandSpec for GitSpec {
                 return RuleMatch {
                     decision: Decision::Ask,
                     reason: "git force-push requires confirmation".into(),
+                    matched: true,
                 };
             }
         }
 
         // Try two-word subcommand first (e.g. "town hack"), fall back to one-word
-        // (e.g. "town") if the two-word form isn't recognized. Same probe pattern
-        // as the gh evaluator — see that module for the rationale.
+        // (e.g. "town") only if the two-word form was unrecognized. If the two-word
+        // form explicitly matched any list (including mutating), that's authoritative
+        // — the one-word fallback must not override it.
         if !sub_two.is_empty() {
             let two_result = self.matcher.evaluate(ctx, "git", &sub_two);
             if two_result.decision == Decision::Allow {
                 return two_result;
             }
-            let one_result = self.matcher.evaluate(ctx, "git", &sub_one);
-            if one_result.decision == Decision::Allow {
-                return one_result;
+            if !two_result.matched {
+                let one_result = self.matcher.evaluate(ctx, "git", &sub_one);
+                if one_result.decision == Decision::Allow {
+                    return one_result;
+                }
             }
             return two_result;
         }

--- a/src/commands/tools/kubectl.rs
+++ b/src/commands/tools/kubectl.rs
@@ -6,35 +6,32 @@
 
 use super::super::CommandSpec;
 use crate::config::KubectlConfig;
-use crate::eval::{CommandContext, Decision, RuleMatch};
-use std::collections::HashMap;
+use crate::eval::matcher::SubcommandMatcher;
+use crate::eval::{CommandContext, RuleMatch};
 
 /// Subcommand-aware kubectl evaluator.
 ///
 /// Evaluation order:
 /// 1. Read-only subcommands → ALLOW (with redirection escalation)
-/// 2. Env-gated subcommands → ALLOW if all `config_env` entries match, else ASK
-/// 3. Known mutating subcommands → ASK
-/// 4. Everything else → ASK
+/// 2. Unconditionally-allowed subcommands → ALLOW (with redirection escalation)
+/// 3. Env-gated subcommands → ALLOW if all `config_env` entries match, else ASK
+/// 4. Known mutating subcommands → ASK
+/// 5. Everything else → ASK
 pub struct KubectlSpec {
-    /// Subcommands that are always allowed (e.g. `get`, `describe`, `logs`).
-    read_only: Vec<String>,
-    /// Known mutating subcommands that always require confirmation.
-    mutating: Vec<String>,
-    /// Subcommands allowed only when all `config_env` entries match.
-    allowed_with_config: Vec<String>,
-    /// Required env var name→value pairs that gate `allowed_with_config` subcommands.
-    config_env: HashMap<String, String>,
+    matcher: SubcommandMatcher,
 }
 
 impl KubectlSpec {
     /// Build a kubectl spec from configuration.
     pub fn from_config(config: &KubectlConfig) -> Self {
         Self {
-            read_only: config.read_only.clone(),
-            mutating: config.mutating.clone(),
-            allowed_with_config: config.allowed_with_config.clone(),
-            config_env: config.config_env.clone(),
+            matcher: SubcommandMatcher::new(
+                config.read_only.clone(),
+                config.allow.clone(),
+                config.mutating.clone(),
+                config.allowed_with_config.clone(),
+                config.config_env.clone(),
+            ),
         }
     }
 
@@ -49,70 +46,21 @@ impl KubectlSpec {
         }
         None
     }
-
-    /// Format config_env keys for reason strings.
-    fn env_keys_display(&self) -> String {
-        let mut keys: Vec<&str> = self.config_env.keys().map(|k| k.as_str()).collect();
-        keys.sort();
-        keys.join(", ")
-    }
 }
 
 impl CommandSpec for KubectlSpec {
     fn evaluate(&self, ctx: &CommandContext) -> RuleMatch {
-        let sub_str = Self::subcommand(ctx).unwrap_or("?");
-
-        if self.read_only.iter().any(|s| s == sub_str) {
-            if let Some(ref r) = ctx.redirection {
-                return RuleMatch {
-                    decision: Decision::Ask,
-                    reason: format!("kubectl {sub_str} with {}", r.description),
-                };
-            }
-            return RuleMatch {
-                decision: Decision::Allow,
-                reason: format!("read-only kubectl {sub_str}"),
-            };
-        }
-
-        // Env-gated subcommands: allowed only when all config_env entries match
-        if self.allowed_with_config.iter().any(|s| s == sub_str) {
-            if !self.config_env.is_empty() && ctx.env_satisfies(&self.config_env) {
-                if let Some(ref r) = ctx.redirection {
-                    return RuleMatch {
-                        decision: Decision::Ask,
-                        reason: format!("kubectl {sub_str} with {}", r.description),
-                    };
-                }
-                return RuleMatch {
-                    decision: Decision::Allow,
-                    reason: format!("kubectl {sub_str} with {}", self.env_keys_display()),
-                };
-            }
-            return RuleMatch {
-                decision: Decision::Ask,
-                reason: format!("kubectl {sub_str} requires confirmation"),
-            };
-        }
-
-        if self.mutating.iter().any(|s| s == sub_str) {
-            return RuleMatch {
-                decision: Decision::Ask,
-                reason: format!("kubectl {sub_str} requires confirmation"),
-            };
-        }
-
-        RuleMatch {
-            decision: Decision::Ask,
-            reason: format!("kubectl {sub_str} requires confirmation"),
-        }
+        let sub = Self::subcommand(ctx).unwrap_or("?");
+        self.matcher.evaluate(ctx, "kubectl", sub)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::Config;
+    use crate::config::{Config, KubectlConfig};
+    use crate::eval::{CommandContext, Decision};
+    use std::collections::HashMap;
 
     /// Clear `KUBECONFIG` from the process environment so the env-gate
     /// fallback in `env_satisfies` doesn't interfere.  Requires nextest.
@@ -169,6 +117,7 @@ mod tests {
     fn spec_with_env_gate() -> KubectlSpec {
         KubectlSpec::from_config(&KubectlConfig {
             read_only: vec!["get".into(), "describe".into()],
+            allow: vec![],
             mutating: vec!["delete".into()],
             allowed_with_config: vec!["apply".into(), "rollout".into()],
             config_env: HashMap::from([("KUBECONFIG".into(), "~/.kube/config.ai".into())]),

--- a/src/commands/tools/mod.rs
+++ b/src/commands/tools/mod.rs
@@ -1,8 +1,9 @@
 //! Subcommand-aware evaluators for specific CLI tools.
 //!
-//! Each module implements `CommandSpec` with tool-specific
-//! logic: subcommand extraction, read-only vs mutating classification,
-//! env-gated auto-allow, and redirection escalation.
+//! Each module implements `CommandSpec` with tool-specific logic: subcommand
+//! extraction, read-only vs mutating classification, env-gated auto-allow,
+//! and redirection escalation. The shared evaluation pipeline lives in
+//! `crate::eval::matcher::SubcommandMatcher`.
 
 /// Subcommand-aware cargo evaluation (build → allow, install → ask, etc.).
 pub mod cargo;

--- a/src/config.rs
+++ b/src/config.rs
@@ -103,6 +103,13 @@ pub struct GitConfig {
     /// Subcommands that are always allowed (e.g. `status`, `log`, `diff`, `branch`).
     #[serde(default)]
     pub read_only: Vec<String>,
+    /// Safe local operations that are always allowed (e.g. git-town local branch management).
+    #[serde(default)]
+    pub allow: Vec<String>,
+    /// Mutating operations that always require confirmation (e.g. remote-affecting or
+    /// filesystem-modifying subcommands that warrant user review).
+    #[serde(default)]
+    pub mutating: Vec<String>,
     /// Subcommands that are allowed only when all `config_env` entries match
     /// (e.g. `push`, `pull` when `GIT_CONFIG_GLOBAL=~/.gitconfig.ai`).
     #[serde(default)]
@@ -125,21 +132,10 @@ pub struct CargoConfig {
     /// Subcommands that are always allowed (e.g. `build`, `test`, `check`, `clippy`).
     #[serde(default)]
     pub safe_subcommands: Vec<String>,
-    /// Subcommands allowed only when all `config_env` entries match.
-    #[serde(default)]
-    pub allowed_with_config: Vec<String>,
-    /// Environment variable requirements for `allowed_with_config` subcommands.
-    #[serde(default)]
-    pub config_env: HashMap<String, String>,
-}
-
-/// kubectl subcommand evaluation rules.
-#[derive(Debug, Deserialize, Serialize, Default)]
-pub struct KubectlConfig {
-    /// Read-only subcommands that are always allowed (e.g. `get`, `describe`, `logs`).
+    /// Additional read-only subcommands (informational, no side effects).
     #[serde(default)]
     pub read_only: Vec<String>,
-    /// Known mutating subcommands that always require confirmation (e.g. `apply`, `delete`).
+    /// Mutating subcommands that always require confirmation.
     #[serde(default)]
     pub mutating: Vec<String>,
     /// Subcommands allowed only when all `config_env` entries match.
@@ -159,7 +155,30 @@ pub struct GhConfig {
     /// Read-only subcommands (e.g. `pr list`, `pr view`, `status`, `api`).
     #[serde(default)]
     pub read_only: Vec<String>,
+    /// Safe subcommands that are always allowed (between read-only and mutating).
+    #[serde(default)]
+    pub allow: Vec<String>,
     /// Known mutating subcommands (e.g. `pr create`, `pr merge`, `repo delete`).
+    #[serde(default)]
+    pub mutating: Vec<String>,
+    /// Subcommands allowed only when all `config_env` entries match.
+    #[serde(default)]
+    pub allowed_with_config: Vec<String>,
+    /// Environment variable requirements for `allowed_with_config` subcommands.
+    #[serde(default)]
+    pub config_env: HashMap<String, String>,
+}
+
+/// kubectl subcommand evaluation rules.
+#[derive(Debug, Deserialize, Serialize, Default)]
+pub struct KubectlConfig {
+    /// Read-only subcommands that are always allowed (e.g. `get`, `describe`, `logs`).
+    #[serde(default)]
+    pub read_only: Vec<String>,
+    /// Safe subcommands that are always allowed (between read-only and mutating).
+    #[serde(default)]
+    pub allow: Vec<String>,
+    /// Known mutating subcommands that always require confirmation (e.g. `apply`, `delete`).
     #[serde(default)]
     pub mutating: Vec<String>,
     /// Subcommands allowed only when all `config_env` entries match.
@@ -238,12 +257,20 @@ struct GitOverlay {
     #[serde(default)]
     read_only: Vec<String>,
     #[serde(default)]
+    allow: Vec<String>,
+    #[serde(default)]
+    mutating: Vec<String>,
+    #[serde(default)]
     allowed_with_config: Vec<String>,
     config_env: Option<HashMap<String, String>>,
     #[serde(default)]
     force_push_flags: Vec<String>,
     #[serde(default)]
     remove_read_only: Vec<String>,
+    #[serde(default)]
+    remove_allow: Vec<String>,
+    #[serde(default)]
+    remove_mutating: Vec<String>,
     #[serde(default)]
     remove_allowed_with_config: Vec<String>,
     #[serde(default)]
@@ -257,10 +284,18 @@ struct CargoOverlay {
     #[serde(default)]
     safe_subcommands: Vec<String>,
     #[serde(default)]
+    read_only: Vec<String>,
+    #[serde(default)]
+    mutating: Vec<String>,
+    #[serde(default)]
     allowed_with_config: Vec<String>,
     config_env: Option<HashMap<String, String>>,
     #[serde(default)]
     remove_safe_subcommands: Vec<String>,
+    #[serde(default)]
+    remove_read_only: Vec<String>,
+    #[serde(default)]
+    remove_mutating: Vec<String>,
     #[serde(default)]
     remove_allowed_with_config: Vec<String>,
 }
@@ -272,12 +307,16 @@ struct KubectlOverlay {
     #[serde(default)]
     read_only: Vec<String>,
     #[serde(default)]
+    allow: Vec<String>,
+    #[serde(default)]
     mutating: Vec<String>,
     #[serde(default)]
     allowed_with_config: Vec<String>,
     config_env: Option<HashMap<String, String>>,
     #[serde(default)]
     remove_read_only: Vec<String>,
+    #[serde(default)]
+    remove_allow: Vec<String>,
     #[serde(default)]
     remove_mutating: Vec<String>,
     #[serde(default)]
@@ -291,12 +330,16 @@ struct GhOverlay {
     #[serde(default)]
     read_only: Vec<String>,
     #[serde(default)]
+    allow: Vec<String>,
+    #[serde(default)]
     mutating: Vec<String>,
     #[serde(default)]
     allowed_with_config: Vec<String>,
     config_env: Option<HashMap<String, String>>,
     #[serde(default)]
     remove_read_only: Vec<String>,
+    #[serde(default)]
+    remove_allow: Vec<String>,
     #[serde(default)]
     remove_mutating: Vec<String>,
     #[serde(default)]
@@ -415,6 +458,13 @@ impl Config {
             &g.remove_read_only,
             g.replace,
         );
+        merge_list(&mut self.git.allow, g.allow, &g.remove_allow, g.replace);
+        merge_list(
+            &mut self.git.mutating,
+            g.mutating,
+            &g.remove_mutating,
+            g.replace,
+        );
         merge_list(
             &mut self.git.allowed_with_config,
             g.allowed_with_config,
@@ -440,6 +490,18 @@ impl Config {
             ca.replace,
         );
         merge_list(
+            &mut self.cargo.read_only,
+            ca.read_only,
+            &ca.remove_read_only,
+            ca.replace,
+        );
+        merge_list(
+            &mut self.cargo.mutating,
+            ca.mutating,
+            &ca.remove_mutating,
+            ca.replace,
+        );
+        merge_list(
             &mut self.cargo.allowed_with_config,
             ca.allowed_with_config,
             &ca.remove_allowed_with_config,
@@ -457,6 +519,7 @@ impl Config {
             &k.remove_read_only,
             k.replace,
         );
+        merge_list(&mut self.kubectl.allow, k.allow, &k.remove_allow, k.replace);
         merge_list(
             &mut self.kubectl.mutating,
             k.mutating,
@@ -481,6 +544,7 @@ impl Config {
             &gh.remove_read_only,
             gh.replace,
         );
+        merge_list(&mut self.gh.allow, gh.allow, &gh.remove_allow, gh.replace);
         merge_list(
             &mut self.gh.mutating,
             gh.mutating,

--- a/src/config.rs
+++ b/src/config.rs
@@ -264,6 +264,8 @@ struct GitOverlay {
     allowed_with_config: Vec<String>,
     config_env: Option<HashMap<String, String>>,
     #[serde(default)]
+    remove_config_env: Vec<String>,
+    #[serde(default)]
     force_push_flags: Vec<String>,
     #[serde(default)]
     remove_read_only: Vec<String>,
@@ -291,6 +293,8 @@ struct CargoOverlay {
     allowed_with_config: Vec<String>,
     config_env: Option<HashMap<String, String>>,
     #[serde(default)]
+    remove_config_env: Vec<String>,
+    #[serde(default)]
     remove_safe_subcommands: Vec<String>,
     #[serde(default)]
     remove_read_only: Vec<String>,
@@ -314,6 +318,8 @@ struct KubectlOverlay {
     allowed_with_config: Vec<String>,
     config_env: Option<HashMap<String, String>>,
     #[serde(default)]
+    remove_config_env: Vec<String>,
+    #[serde(default)]
     remove_read_only: Vec<String>,
     #[serde(default)]
     remove_allow: Vec<String>,
@@ -336,6 +342,8 @@ struct GhOverlay {
     #[serde(default)]
     allowed_with_config: Vec<String>,
     config_env: Option<HashMap<String, String>>,
+    #[serde(default)]
+    remove_config_env: Vec<String>,
     #[serde(default)]
     remove_read_only: Vec<String>,
     #[serde(default)]
@@ -477,8 +485,16 @@ impl Config {
             &g.remove_force_push_flags,
             g.replace,
         );
+        for key in &g.remove_config_env {
+            self.git.config_env.remove(key);
+        }
         if let Some(v) = g.config_env {
-            self.git.config_env = v;
+            self.git.config_env.extend(v);
+        }
+        if self.git.force_push_flags.is_empty() {
+            eprintln!(
+                "cc-toolgate: warning: git.force_push_flags is empty — force-push detection disabled"
+            );
         }
 
         // Cargo
@@ -507,8 +523,11 @@ impl Config {
             &ca.remove_allowed_with_config,
             ca.replace,
         );
+        for key in &ca.remove_config_env {
+            self.cargo.config_env.remove(key);
+        }
         if let Some(v) = ca.config_env {
-            self.cargo.config_env = v;
+            self.cargo.config_env.extend(v);
         }
 
         // Kubectl
@@ -532,8 +551,11 @@ impl Config {
             &k.remove_allowed_with_config,
             k.replace,
         );
+        for key in &k.remove_config_env {
+            self.kubectl.config_env.remove(key);
+        }
         if let Some(v) = k.config_env {
-            self.kubectl.config_env = v;
+            self.kubectl.config_env.extend(v);
         }
 
         // Gh
@@ -557,8 +579,11 @@ impl Config {
             &gh.remove_allowed_with_config,
             gh.replace,
         );
+        for key in &gh.remove_config_env {
+            self.gh.config_env.remove(key);
+        }
         if let Some(v) = gh.config_env {
-            self.gh.config_env = v;
+            self.gh.config_env.extend(v);
         }
     }
 
@@ -922,10 +947,16 @@ mod tests {
             r#"
             [git]
             allowed_with_config = ["push"]
-            config_env_var = "GIT_CONFIG_GLOBAL"
+            [git.config_env]
+            GIT_CONFIG_GLOBAL = "~/.gitconfig.ai"
         "#,
         );
         assert_eq!(config.kubectl.read_only, original_kubectl_read_only);
+        assert_eq!(config.git.allowed_with_config, vec!["push"]);
+        assert_eq!(
+            config.git.config_env.get("GIT_CONFIG_GLOBAL").unwrap(),
+            "~/.gitconfig.ai"
+        );
     }
 
     #[test]

--- a/src/eval/context.rs
+++ b/src/eval/context.rs
@@ -2,6 +2,32 @@
 
 use crate::parse::Redirection;
 
+/// Compare a command env var value against a config value (raw and shell-expanded forms).
+///
+/// Tries three strategies in order:
+/// 1. Exact raw match (`cmd_val == config_raw`)
+/// 2. Expanded match (`cmd_val == config_expanded`)
+/// 3. Canonicalization fallback: shell-expand `cmd_val`, then `std::fs::canonicalize` both
+fn paths_match(cmd_val: &str, config_raw: &str, config_expanded: &str) -> bool {
+    // 1. Raw match
+    if cmd_val == config_raw {
+        return true;
+    }
+    // 2. Expanded match
+    if cmd_val == config_expanded {
+        return true;
+    }
+    // 3. Canonicalization fallback: expand cmd_val too, canonicalize both
+    let cmd_expanded = shellexpand::full(cmd_val).unwrap_or(std::borrow::Cow::Borrowed(cmd_val));
+    if let (Ok(cc), Ok(ce)) = (
+        std::fs::canonicalize(cmd_expanded.as_ref()),
+        std::fs::canonicalize(config_expanded),
+    ) {
+        return cc == ce;
+    }
+    false
+}
+
 /// Context for evaluating a single command segment.
 #[derive(Debug)]
 pub struct CommandContext<'a> {
@@ -58,14 +84,14 @@ impl<'a> CommandContext<'a> {
             };
             // Check inline env vars first (may contain literal ~ or expanded path)
             if let Some((_, v)) = self.env_vars.iter().find(|(k, _)| k == key) {
-                return v == value || v == expanded.as_ref();
+                return paths_match(v, value, expanded.as_ref());
             }
             // Check accumulated env from prior compound-command segments
             if let Some(v) = self.accumulated_env.get(key) {
-                return v == value || v == expanded.as_ref();
+                return paths_match(v, value, expanded.as_ref());
             }
             // Fall back to process environment (shell will have expanded already)
-            std::env::var(key).is_ok_and(|v| v == *value || v == expanded.as_ref())
+            std::env::var(key).is_ok_and(|v| paths_match(&v, value, expanded.as_ref()))
         })
     }
 
@@ -249,5 +275,46 @@ mod tests {
         let req = HashMap::from([(COLLISION_KEY.into(), "beta".into())]);
         assert!(ctx.env_satisfies(&req), "expected 'beta', env was tampered");
         unsafe { std::env::remove_var(COLLISION_KEY) };
+    }
+
+    #[test]
+    fn env_satisfies_symlink_canonicalization() {
+        require_nextest();
+
+        // Create a real temp dir and a symlink dir pointing to it
+        let base = std::env::temp_dir().join("cc_toolgate_symlink_test_env_satisfies");
+        let real_dir = base.join("real");
+        let link_dir = base.join("link");
+
+        std::fs::create_dir_all(&real_dir).unwrap();
+        // Remove stale symlink if it exists
+        let _ = std::fs::remove_file(&link_dir);
+        std::os::unix::fs::symlink(&real_dir, &link_dir).unwrap();
+        std::fs::write(real_dir.join("marker"), b"x").unwrap();
+
+        let real_str = real_dir.to_str().unwrap();
+        let link_str = link_dir.to_str().unwrap();
+
+        // Case 1: command uses symlink path, config has real/canonical path
+        let cmd1 = format!("MY_PATH={link_str} git push");
+        let ctx1 = CommandContext::from_command(&cmd1);
+        let req1 = HashMap::from([("MY_PATH".into(), real_str.to_string())]);
+        assert!(
+            ctx1.env_satisfies(&req1),
+            "symlink path in command should match canonical config path"
+        );
+
+        // Case 2: command uses real path, config has symlink path
+        let cmd2 = format!("MY_PATH={real_str} git push");
+        let ctx2 = CommandContext::from_command(&cmd2);
+        let req2 = HashMap::from([("MY_PATH".into(), link_str.to_string())]);
+        assert!(
+            ctx2.env_satisfies(&req2),
+            "real path in command should match symlink config path (canonicalized)"
+        );
+
+        // Cleanup
+        let _ = std::fs::remove_file(&link_dir);
+        let _ = std::fs::remove_dir_all(&base);
     }
 }

--- a/src/eval/decision.rs
+++ b/src/eval/decision.rs
@@ -42,4 +42,11 @@ pub struct RuleMatch {
     pub decision: Decision,
     /// Human-readable explanation of why this decision was reached.
     pub reason: String,
+    /// Whether the subcommand was explicitly matched in a classification list.
+    ///
+    /// `true` for steps 1–4 (read_only, allow, allowed_with_config, mutating).
+    /// `false` for step 5 (fallthrough / unrecognized subcommand).
+    /// Used by multi-word probe logic: only try the one-word fallback when the
+    /// two-word result was unrecognized (i.e. `matched == false`).
+    pub matched: bool,
 }

--- a/src/eval/matcher.rs
+++ b/src/eval/matcher.rs
@@ -1,0 +1,305 @@
+//! Data-driven subcommand matcher for tool evaluators.
+//!
+//! [`SubcommandMatcher`] is a concrete struct that holds the five common
+//! subcommand classification lists and implements the standard evaluation
+//! pipeline. Tool evaluators (git, cargo, kubectl, gh) construct one from
+//! their config and delegate to it, keeping tool-specific logic (subcommand
+//! extraction, pre-checks like force-push detection) in the spec itself.
+//!
+//! ## Evaluation pipeline
+//!
+//! 1. `read_only` match → ALLOW (redirection escalates to ASK)
+//! 2. `allow` match → ALLOW (redirection escalates to ASK)
+//! 3. `allowed_with_config` match → ALLOW if `config_env` satisfied, else ASK
+//! 4. `mutating` match → ASK
+//! 5. Fallthrough → ASK
+
+use crate::eval::{CommandContext, Decision, RuleMatch};
+use std::collections::HashMap;
+
+/// Shared subcommand evaluation logic for all tool evaluators.
+///
+/// Holds the five standard classification lists and applies the evaluation
+/// pipeline. Tool specs construct a `SubcommandMatcher` from their config
+/// and call [`evaluate`](Self::evaluate) after any tool-specific pre-checks.
+pub(crate) struct SubcommandMatcher {
+    /// Subcommands that are always allowed without conditions (e.g. `status`, `log`, `get`).
+    read_only: Vec<String>,
+    /// Subcommands that are unconditionally allowed (e.g. git-town local branch ops).
+    allow: Vec<String>,
+    /// Subcommands that always require user confirmation (e.g. `push`, `apply`, `delete`).
+    mutating: Vec<String>,
+    /// Subcommands allowed only when all `config_env` entries match.
+    allowed_with_config: Vec<String>,
+    /// Required env var name→value pairs that gate `allowed_with_config` subcommands.
+    config_env: HashMap<String, String>,
+}
+
+impl SubcommandMatcher {
+    /// Construct a matcher with the given classification lists.
+    pub fn new(
+        read_only: Vec<String>,
+        allow: Vec<String>,
+        mutating: Vec<String>,
+        allowed_with_config: Vec<String>,
+        config_env: HashMap<String, String>,
+    ) -> Self {
+        Self {
+            read_only,
+            allow,
+            mutating,
+            allowed_with_config,
+            config_env,
+        }
+    }
+
+    /// Format `config_env` keys for reason strings (e.g. `"GIT_CONFIG_GLOBAL"`).
+    ///
+    /// Keys are sorted for deterministic output.
+    fn env_keys_display(&self) -> String {
+        let mut keys: Vec<&str> = self.config_env.keys().map(|k| k.as_str()).collect();
+        keys.sort();
+        keys.join(", ")
+    }
+
+    /// Run the standard evaluation pipeline for a subcommand.
+    ///
+    /// `tool` is the tool name used in reason strings (e.g. `"git"`, `"cargo"`).
+    /// `sub` is the extracted subcommand string (e.g. `"push"`, `"pr list"`).
+    ///
+    /// Evaluation order:
+    /// 1. `read_only` match → ALLOW (redirection escalates to ASK)
+    /// 2. `allow` match → ALLOW (redirection escalates to ASK)
+    /// 3. `allowed_with_config` match → ALLOW if `config_env` satisfied, else ASK
+    /// 4. `mutating` match → ASK
+    /// 5. Fallthrough → ASK
+    pub fn evaluate(&self, ctx: &CommandContext, tool: &str, sub: &str) -> RuleMatch {
+        // 1. Read-only: always allowed, redirection escalates.
+        if self.read_only.iter().any(|s| s == sub) {
+            if let Some(ref r) = ctx.redirection {
+                return RuleMatch {
+                    decision: Decision::Ask,
+                    reason: format!("{tool} {sub} with {}", r.description),
+                };
+            }
+            return RuleMatch {
+                decision: Decision::Allow,
+                reason: format!("read-only {tool} {sub}"),
+            };
+        }
+
+        // 2. Unconditionally allowed, redirection escalates.
+        if self.allow.iter().any(|s| s == sub) {
+            if let Some(ref r) = ctx.redirection {
+                return RuleMatch {
+                    decision: Decision::Ask,
+                    reason: format!("{tool} {sub} with {}", r.description),
+                };
+            }
+            return RuleMatch {
+                decision: Decision::Allow,
+                reason: format!("allowed: {tool} {sub}"),
+            };
+        }
+
+        // 3. Env-gated: allowed only when all config_env entries match.
+        if self.allowed_with_config.iter().any(|s| s == sub) {
+            if !self.config_env.is_empty() && ctx.env_satisfies(&self.config_env) {
+                if let Some(ref r) = ctx.redirection {
+                    return RuleMatch {
+                        decision: Decision::Ask,
+                        reason: format!("{tool} {sub} with {}", r.description),
+                    };
+                }
+                return RuleMatch {
+                    decision: Decision::Allow,
+                    reason: format!("{tool} {sub} with {}", self.env_keys_display()),
+                };
+            }
+            return RuleMatch {
+                decision: Decision::Ask,
+                reason: format!("{tool} {sub} requires confirmation"),
+            };
+        }
+
+        // 4. Explicitly mutating → ASK.
+        if self.mutating.iter().any(|s| s == sub) {
+            return RuleMatch {
+                decision: Decision::Ask,
+                reason: format!("{tool} {sub} requires confirmation"),
+            };
+        }
+
+        // 5. Fallthrough → ASK.
+        RuleMatch {
+            decision: Decision::Ask,
+            reason: format!("{tool} {sub} requires confirmation"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::eval::CommandContext;
+    use std::collections::HashMap;
+
+    /// Panic unless running under nextest (process-per-test isolation).
+    fn require_nextest() {
+        assert!(
+            std::env::var("NEXTEST").is_ok(),
+            "this test mutates process env and requires nextest (cargo nextest run)"
+        );
+    }
+
+    fn matcher_basic() -> SubcommandMatcher {
+        SubcommandMatcher::new(
+            vec!["status".into(), "log".into()],
+            vec!["town hack".into()],
+            vec!["push".into()],
+            vec![],
+            HashMap::new(),
+        )
+    }
+
+    fn matcher_with_env_gate() -> SubcommandMatcher {
+        SubcommandMatcher::new(
+            vec!["status".into()],
+            vec![],
+            vec!["delete".into()],
+            vec!["apply".into()],
+            HashMap::from([("KUBECONFIG".into(), "~/.kube/config.ai".into())]),
+        )
+    }
+
+    // ── read_only ──
+
+    #[test]
+    fn read_only_allows() {
+        let m = matcher_basic();
+        let ctx = CommandContext::from_command("git status");
+        let r = m.evaluate(&ctx, "git", "status");
+        assert_eq!(r.decision, Decision::Allow);
+        assert!(r.reason.contains("read-only"));
+    }
+
+    #[test]
+    fn read_only_with_redirection_asks() {
+        let m = matcher_basic();
+        let ctx = CommandContext::from_command("git log > /tmp/log.txt");
+        let r = m.evaluate(&ctx, "git", "log");
+        assert_eq!(r.decision, Decision::Ask);
+    }
+
+    // ── allow ──
+
+    #[test]
+    fn allow_list_allows() {
+        let m = matcher_basic();
+        let ctx = CommandContext::from_command("git town hack feature");
+        let r = m.evaluate(&ctx, "git", "town hack");
+        assert_eq!(r.decision, Decision::Allow);
+        assert!(r.reason.contains("allowed:"));
+    }
+
+    #[test]
+    fn allow_with_redirection_asks() {
+        let m = SubcommandMatcher::new(
+            vec![],
+            vec!["safe-cmd".into()],
+            vec![],
+            vec![],
+            HashMap::new(),
+        );
+        let ctx = CommandContext::from_command("tool safe-cmd > out.txt");
+        let r = m.evaluate(&ctx, "tool", "safe-cmd");
+        assert_eq!(r.decision, Decision::Ask);
+    }
+
+    // ── mutating ──
+
+    #[test]
+    fn mutating_asks() {
+        let m = matcher_basic();
+        let ctx = CommandContext::from_command("git push origin main");
+        let r = m.evaluate(&ctx, "git", "push");
+        assert_eq!(r.decision, Decision::Ask);
+    }
+
+    // ── fallthrough ──
+
+    #[test]
+    fn unknown_subcommand_asks() {
+        let m = matcher_basic();
+        let ctx = CommandContext::from_command("git unknown-sub");
+        let r = m.evaluate(&ctx, "git", "unknown-sub");
+        assert_eq!(r.decision, Decision::Ask);
+        assert!(r.reason.contains("requires confirmation"));
+    }
+
+    // ── env-gated ──
+
+    #[test]
+    fn env_gated_with_matching_env_allows() {
+        let m = matcher_with_env_gate();
+        let ctx = CommandContext::from_command(
+            "KUBECONFIG=~/.kube/config.ai kubectl apply -f deploy.yaml",
+        );
+        let r = m.evaluate(&ctx, "kubectl", "apply");
+        assert_eq!(r.decision, Decision::Allow);
+        assert!(r.reason.contains("KUBECONFIG"));
+    }
+
+    #[test]
+    fn env_gated_with_wrong_env_asks() {
+        let m = matcher_with_env_gate();
+        let ctx = CommandContext::from_command("KUBECONFIG=~/.kube/config kubectl apply -f f.yaml");
+        let r = m.evaluate(&ctx, "kubectl", "apply");
+        assert_eq!(r.decision, Decision::Ask);
+    }
+
+    #[test]
+    fn env_gated_without_env_asks() {
+        require_nextest();
+        // Requires process isolation: KUBECONFIG may be set in the real environment.
+        unsafe { std::env::remove_var("KUBECONFIG") };
+        let m = matcher_with_env_gate();
+        let ctx = CommandContext::from_command("kubectl apply -f deploy.yaml");
+        let r = m.evaluate(&ctx, "kubectl", "apply");
+        assert_eq!(r.decision, Decision::Ask);
+    }
+
+    #[test]
+    fn env_gated_with_redirection_asks() {
+        let m = matcher_with_env_gate();
+        let ctx = CommandContext::from_command(
+            "KUBECONFIG=~/.kube/config.ai kubectl apply -f f.yaml > out",
+        );
+        let r = m.evaluate(&ctx, "kubectl", "apply");
+        assert_eq!(r.decision, Decision::Ask);
+    }
+
+    // ── env_keys_display ──
+
+    #[test]
+    fn env_keys_display_sorted() {
+        let m = SubcommandMatcher::new(
+            vec![],
+            vec![],
+            vec![],
+            vec!["deploy".into()],
+            HashMap::from([
+                ("ZEBRA_VAR".into(), "z".into()),
+                ("ALPHA_VAR".into(), "a".into()),
+            ]),
+        );
+        // Keys are sorted
+        assert_eq!(m.env_keys_display(), "ALPHA_VAR, ZEBRA_VAR");
+    }
+
+    #[test]
+    fn env_keys_display_empty() {
+        let m = SubcommandMatcher::new(vec![], vec![], vec![], vec![], HashMap::new());
+        assert_eq!(m.env_keys_display(), "");
+    }
+}

--- a/src/eval/matcher.rs
+++ b/src/eval/matcher.rs
@@ -44,6 +44,23 @@ impl SubcommandMatcher {
         allowed_with_config: Vec<String>,
         config_env: HashMap<String, String>,
     ) -> Self {
+        let lists: [(&[String], &str); 4] = [
+            (&read_only, "read_only"),
+            (&allow, "allow"),
+            (&mutating, "mutating"),
+            (&allowed_with_config, "allowed_with_config"),
+        ];
+        for (i, (list_a, name_a)) in lists.iter().enumerate() {
+            for (list_b, name_b) in &lists[i + 1..] {
+                for item in list_a.iter() {
+                    if list_b.contains(item) {
+                        log::warn!(
+                            "subcommand \"{item}\" in both {name_a} and {name_b} — {name_a} takes precedence"
+                        );
+                    }
+                }
+            }
+        }
         Self {
             read_only,
             allow,
@@ -80,11 +97,13 @@ impl SubcommandMatcher {
                 return RuleMatch {
                     decision: Decision::Ask,
                     reason: format!("{tool} {sub} with {}", r.description),
+                    matched: true,
                 };
             }
             return RuleMatch {
                 decision: Decision::Allow,
                 reason: format!("read-only {tool} {sub}"),
+                matched: true,
             };
         }
 
@@ -94,11 +113,13 @@ impl SubcommandMatcher {
                 return RuleMatch {
                     decision: Decision::Ask,
                     reason: format!("{tool} {sub} with {}", r.description),
+                    matched: true,
                 };
             }
             return RuleMatch {
                 decision: Decision::Allow,
                 reason: format!("allowed: {tool} {sub}"),
+                matched: true,
             };
         }
 
@@ -109,16 +130,19 @@ impl SubcommandMatcher {
                     return RuleMatch {
                         decision: Decision::Ask,
                         reason: format!("{tool} {sub} with {}", r.description),
+                        matched: true,
                     };
                 }
                 return RuleMatch {
                     decision: Decision::Allow,
                     reason: format!("{tool} {sub} with {}", self.env_keys_display()),
+                    matched: true,
                 };
             }
             return RuleMatch {
                 decision: Decision::Ask,
                 reason: format!("{tool} {sub} requires confirmation"),
+                matched: true,
             };
         }
 
@@ -127,6 +151,7 @@ impl SubcommandMatcher {
             return RuleMatch {
                 decision: Decision::Ask,
                 reason: format!("{tool} {sub} requires confirmation"),
+                matched: true,
             };
         }
 
@@ -134,6 +159,7 @@ impl SubcommandMatcher {
         RuleMatch {
             decision: Decision::Ask,
             reason: format!("{tool} {sub} requires confirmation"),
+            matched: false,
         }
     }
 }

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -319,6 +319,7 @@ impl CommandRegistry {
             return RuleMatch {
                 decision: Decision::Allow,
                 reason: "empty".into(),
+                matched: true,
             };
         }
 
@@ -328,6 +329,7 @@ impl CommandRegistry {
             return RuleMatch {
                 decision: Decision::Allow,
                 reason: format!("variable assignment: {}", words[0]),
+                matched: true,
             };
         }
 
@@ -362,6 +364,7 @@ impl CommandRegistry {
             return self.maybe_escalate(RuleMatch {
                 decision: strictest,
                 reason,
+                matched: true,
             });
         }
 
@@ -382,6 +385,7 @@ impl CommandRegistry {
         RuleMatch {
             decision: Decision::Ask,
             reason: format!("unrecognized command: {}", ctx.base_command),
+            matched: false,
         }
     }
 
@@ -506,6 +510,7 @@ impl CommandRegistry {
         self.maybe_annotate_project_overlay(RuleMatch {
             decision: strictest,
             reason: format!("{}:\n{}", header, reasons.join("\n")),
+            matched: true,
         })
     }
 }

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -9,6 +9,8 @@
 pub mod context;
 /// Decision enum and rule match types.
 pub mod decision;
+/// Data-driven subcommand matcher shared by all tool evaluators.
+pub(crate) mod matcher;
 
 pub use context::CommandContext;
 pub use decision::{Decision, RuleMatch};

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -702,6 +702,33 @@ decision_test!(ask_git_town_repo, "git town repo", Ask);
 
 decision_test!(allow_git_fetch, "git fetch origin", Allow);
 
+// ── two-word mutating overrides one-word read_only ──
+
+decision_test!(ask_stash_drop, "git stash drop", Ask);
+decision_test!(ask_stash_clear, "git stash clear", Ask);
+decision_test!(allow_stash_bare, "git stash", Allow);
+decision_test!(
+    ask_remote_add,
+    "git remote add upstream https://example.com",
+    Ask
+);
+decision_test!(ask_remote_remove, "git remote remove upstream", Ask);
+decision_test!(allow_remote_bare, "git remote", Allow);
+decision_test!(allow_git_town_bare, "git town", Allow);
+
+// ── gh global flag skipping ──
+
+decision_test!(
+    allow_gh_hostname_pr_list,
+    "gh --hostname github.com pr list",
+    Allow
+);
+decision_test!(
+    allow_gh_repo_flag_pr_view,
+    "gh -R owner/repo pr view 123",
+    Allow
+);
+
 // ── Pipeline redirection propagation (issue #37) ──
 
 decision_test!(

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -668,6 +668,40 @@ fn export_and_assign_before_redirect_segments_not_escalated() {
     );
 }
 
+// ── source/. moved to ask (issue #22) ──
+
+decision_test!(ask_source_script, "source ~/.bashrc", Ask);
+decision_test!(ask_dot_script, ". /etc/profile", Ask);
+
+// ── git-town: read-only ──
+
+decision_test!(allow_git_town_branch, "git town branch", Allow);
+decision_test!(allow_git_town_status, "git town status", Allow);
+decision_test!(allow_git_town_config, "git town config", Allow);
+decision_test!(allow_git_town_diff_parent, "git town diff-parent", Allow);
+
+// ── git-town: safe local operations ──
+
+decision_test!(allow_git_town_hack, "git town hack my-branch", Allow);
+decision_test!(allow_git_town_append, "git town append child-branch", Allow);
+decision_test!(allow_git_town_compress, "git town compress", Allow);
+decision_test!(allow_git_town_switch, "git town switch", Allow);
+decision_test!(allow_git_town_undo, "git town undo", Allow);
+decision_test!(allow_git_town_prepend, "git town prepend parent", Allow);
+decision_test!(allow_git_town_set_parent, "git town set-parent", Allow);
+
+// ── git-town: mutating (remote-affecting) ──
+
+decision_test!(ask_git_town_sync, "git town sync", Ask);
+decision_test!(ask_git_town_ship, "git town ship", Ask);
+decision_test!(ask_git_town_propose, "git town propose", Ask);
+decision_test!(ask_git_town_delete, "git town delete", Ask);
+decision_test!(ask_git_town_repo, "git town repo", Ask);
+
+// ── git fetch is read-only ──
+
+decision_test!(allow_git_fetch, "git fetch origin", Allow);
+
 // ── Pipeline redirection propagation (issue #37) ──
 
 decision_test!(


### PR DESCRIPTION
## Summary

**cc-toolgate v0.7.0** — shared subcommand matcher, path canonicalization, git-town support.

- **Shared SubcommandMatcher** (`src/eval/matcher.rs`): Extracts the repeated read-only → allow → env-gated → mutating → fallthrough evaluation pipeline from all four tool evaluators into a shared struct. Each evaluator constructs a matcher from its config and delegates to it, keeping only tool-specific logic (git force-push detection, cargo `--version` flag).

- **Two-word subcommand probing with `matched` guard**: Enables multi-word subcommand classification (e.g., `git town hack` → `"town hack"` in config). Two-word matches are authoritative — the one-word fallback only fires when the two-word form was unrecognized (fallthrough), preventing read_only one-word prefixes from silently overriding two-word mutating entries.

- **Path canonicalization for config_env**: `paths_match()` uses `std::fs::canonicalize()` as fallback to resolve symlinks. Fixes matching on systems where `/home` → `/var/home`.

- **Git-town commands classified**: read-only (informational), allow (safe local branch ops), mutating (sync, ship, propose, delete, repo). Dangerous two-word overrides for stash drop/clear, remote add/remove/rename/set-url.

- **Move source/. to ask** (closes #22): Same risk class as `eval`.

- **Config improvements**: `allow` and `mutating` fields added to all tool sections. `config_env` overlay now merges (extend) instead of replacing, with `remove_config_env` support. Warning when `force_push_flags` is empty after merge. Duplicate-list validation in SubcommandMatcher.

- **gh flag skipping**: Global flags (`--hostname`, `-R`/`--repo`) now skipped before subcommand extraction.

- **CI updates**: Version 0.7.0. Clippy 1.95 lint fix. Rust toolchain action updated. cargo-deny bumped to v2.0.17. semver-checks job added (closes #33). Automated Claude Code review workflow removed.

## Test plan

- [x] 477 tests pass, 0 failures
- [x] `cargo fmt -- --check` clean
- [x] `cargo clippy -- -D warnings` clean (1.95)
- [x] `cargo doc --no-deps` clean
- [x] CI green: test, audit, msrv, cross-compile (3 platforms), semver-checks
- [x] Integration tests: git-town (read-only, allow, mutating), source/. → Ask, git fetch, stash drop/clear → Ask, remote add/remove → Ask, bare `git town` → Allow, gh global flag skipping
- [x] Unit test: symlink path canonicalization (both directions)
- [x] Code review: P1 security bypass fixed (two-word probe fallback), P2s addressed (gh flags, config_env merge, force_push_flags warning, stash/remote classification)

Closes #22, closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)