### PR TITLE
chore: bump MSRV to Rust 1.95

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,7 +68,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9 # master (2026-02-13)
         with:
-          toolchain: "1.88"
+          toolchain: "1.95"
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           key: msrv

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/butterflyskies/cc-toolgate"
 readme = "README.md"
 keywords = ["claude-code", "hooks", "security", "shell", "toolgate"]
 categories = ["command-line-utilities", "development-tools"]
-rust-version = "1.88"
+rust-version = "1.95"
 
 [dependencies]
 agent-shell-parser = "0.5.0"


### PR DESCRIPTION
## Summary

- Bump `rust-version` in Cargo.toml from 1.88 to 1.95
- Update CI MSRV check job to use toolchain 1.95

Unblocks edition 2024 idioms for upcoming refactors.

Closes #58